### PR TITLE
Fixing issue with some odd cases (high non-ascii chars), adding supporting test cases

### DIFF
--- a/NSString+IndefiniteArticle.podspec
+++ b/NSString+IndefiniteArticle.podspec
@@ -1,22 +1,9 @@
-#
-#  Be sure to run `pod spec lint NSString+IndefiniteArticle.podspec' to ensure this is a
-#  valid spec and to remove all comments including this before submitting the spec.
-#
-#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
-#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
-#
-
 Pod::Spec.new do |s|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
-  #  These will help people to find your library, and whilst it
-  #  can feel like a chore to fill in it's definitely to your advantage. The
-  #  summary should be tweet-length, and the description more in depth.
-  #
-
   s.name         = "NSString+IndefiniteArticle"
-  s.version      = "0.1.0"
+  s.version      = "0.1.1"
   s.summary      = "An NSString category for providing an indefinite articles (a|an)"
 
   s.description  = <<-DESC
@@ -31,93 +18,40 @@ Pod::Spec.new do |s|
                     or you can call it on a given string:
 
                     * `[@"historic event" indefiniteArticle] => @"a"`
+                    * `[@"800 lb gorilla" indefiniteArticle] => @"an"`
 
                    DESC
 
   s.homepage     = "https://github.com/barclay/NSString-IndefiniteArticle"
-  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
 
 
   # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
-  #  Licensing your code is important. See http://choosealicense.com for more info.
-  #  CocoaPods will detect a license file if there is a named LICENSE*
-  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
-  #
-
   s.license      = { :type => "MIT", :file => "LICENSE" }
 
 
   # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
-  #  Specify the authors of the library, with email addresses. Email addresses
-  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
-  #  accepts just a name if you'd rather not provide an email address.
-  #
-  #  Specify a social_media_url where others can refer to, for example a twitter
-  #  profile URL.
-  #
-
   s.author             = { "barclay loftus" => "barclay@distinctpixel.com" }
-  # Or just: s.author    = "barclay loftus"
-  # s.authors            = { "barclay loftus" => "barclay@distinctpixel.com" }
   s.social_media_url   = "http://twitter.com/barclay"
 
-  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If this Pod runs only on iOS or OS X, then specify the platform and
-  #  the deployment target. You can optionally include the target after the platform.
-  #
-
-  # s.platform     = :ios
-  # s.platform     = :ios, "5.0"
-
-  #  When using multiple platforms
-  # s.ios.deployment_target = "5.0"
-  # s.osx.deployment_target = "10.7"
-
-
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #  Specify the location from where the source should be retrieved.
-  #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/barclay/NSString-IndefiniteArticle.git", :tag => "0.1.0" }
+  s.source       = { :git => "https://github.com/barclay/NSString-IndefiniteArticle.git", :tag => "0.1.1" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
-  #  CocoaPods is smart about how it includes source code. For source files
-  #  giving a folder will include any swift, h, m, mm, c & cpp files.
-  #  For header files it will include any header in the folder.
-  #  Not including the public_header_files will make all headers public.
-  #
-
   s.source_files  = "Source", "Source/**/*.{h,m}"
 
 
   # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
-  #  Link your library with frameworks, or libraries. Libraries do not include
-  #  the lib prefix of their name.
-  #
-
-  # s.framework  = "SomeFramework"
-  # s.frameworks = "SomeFramework", "AnotherFramework"
-
-  # s.library   = "iconv"
-  # s.libraries = "iconv", "xml2"
 
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
-  #  If your library depends on compiler flags you can set them in the xcconfig hash
-  #  where they will only apply to your library. If you depend on other Podspecs
-  #  you can include multiple dependencies to ensure it works.
-
   s.requires_arc = true
-
-  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
-  # s.dependency "JSONKit", "~> 1.4"
 
 end

--- a/NSString+IndefiniteArticle.xcodeproj/project.pbxproj
+++ b/NSString+IndefiniteArticle.xcodeproj/project.pbxproj
@@ -7,11 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		634B37EC1ABF381E00ECA40D /* NSString+IndefiniteArticle.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 634B37EB1ABF381E00ECA40D /* NSString+IndefiniteArticle.podspec */; };
 		63A052F11AB9E19100483CB5 /* NSString_IndefiniteArticleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A052F01AB9E19100483CB5 /* NSString_IndefiniteArticleTests.m */; };
 		63A052FC1ABA0D9400483CB5 /* NSString+IndefiniteArticle.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A052FB1ABA0D9400483CB5 /* NSString+IndefiniteArticle.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		634B37EB1ABF381E00ECA40D /* NSString+IndefiniteArticle.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "NSString+IndefiniteArticle.podspec"; sourceTree = "<group>"; };
 		63A052EB1AB9E19100483CB5 /* NSString+IndefiniteArticleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "NSString+IndefiniteArticleTests.xctest"; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		63A052EF1AB9E19100483CB5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		63A052F01AB9E19100483CB5 /* NSString_IndefiniteArticleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSString_IndefiniteArticleTests.m; sourceTree = "<group>"; };
@@ -33,6 +35,7 @@
 		63A052DE1AB9E12100483CB5 = {
 			isa = PBXGroup;
 			children = (
+				634B37EB1ABF381E00ECA40D /* NSString+IndefiniteArticle.podspec */,
 				63A052FA1ABA0D9400483CB5 /* NSString+IndefiniteArticle.h */,
 				63A052FB1ABA0D9400483CB5 /* NSString+IndefiniteArticle.m */,
 				63A052ED1AB9E19100483CB5 /* Tests */,
@@ -120,6 +123,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				634B37EC1ABF381E00ECA40D /* NSString+IndefiniteArticle.podspec in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/NSString+IndefiniteArticle.m
+++ b/Source/NSString+IndefiniteArticle.m
@@ -27,8 +27,8 @@
     // specific "an" patterns
     //   words starting with a soft h: domino eats an hour, an honest man.
     //   words starting with a soft vowel: domino eats an apple, an elephant, an orange
-    //   or anything that leads with 8: domino eats an 8, an 800 lb gorilla
     //   or any single letters with a soft vowel sound: domino eats an a, an a, an r, an x
+    //   or anything that leads with 8: domino eats an 8, an 800 lb gorilla
     //
     NSString *an_patterns = @"^(([aefhilmnorsx]$)|(hono|honest|hour|heir|[aeiou]|8))";
     
@@ -46,10 +46,20 @@
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\w+" options:NSRegularExpressionCaseInsensitive error:&error];
     NSArray *matches = [regex matchesInString:str options:0 range:NSMakeRange(0, str.length)];
 
-    // weird case: no match (input was empty), we'll just return nothing.
+    // weird case: no match (input was empty), this could happen if it's either
+    // an empty string, or something non-word charactor like.
     //
-    if ([matches count] == 0)
-        return @"";
+    if ([matches count] == 0) {
+        
+        // if it's truly empty, then return empty.
+        //
+        if ([str length] == 0)
+            return @"";
+        
+        // otherwise, let's defualt to an "a", i.e. "a ©".
+        //
+        return a;
+    }
     
     // Get the first word in the string
     //

--- a/Tests/NSString_IndefiniteArticleTests.m
+++ b/Tests/NSString_IndefiniteArticleTests.m
@@ -40,7 +40,7 @@
     XCTAssertEqualObjects([@"z" indefiniteArticle], @"a");
 }
 
-- (void)testSpecialHCases
+- (void)testSpecialSoftHCases
 {
     XCTAssertEqualObjects([@"hourly" indefiniteArticle], @"an");
     XCTAssertEqualObjects([@"honest" indefiniteArticle], @"an");
@@ -54,16 +54,6 @@
     XCTAssertEqualObjects([@"zebra" indefiniteArticle], @"a");
 }
 
-- (void)testSpecialCapitalCases
-{
-    XCTAssertEqualObjects([@"MN"  indefiniteArticle], @"an");
-    XCTAssertEqualObjects([@"FAA" indefiniteArticle], @"an");
-    XCTAssertEqualObjects([@"JOB" indefiniteArticle], @"a");
-    XCTAssertEqualObjects([@"URL" indefiniteArticle], @"a");
-    XCTAssertEqualObjects([@"USB" indefiniteArticle], @"a");
-    XCTAssertEqualObjects([@"XIP" indefiniteArticle], @"an");
-}
-
 - (void)testWordsThatBeginWithVowels
 {
     XCTAssertEqualObjects([@"elipsis" indefiniteArticle], @"an");
@@ -75,6 +65,23 @@
     XCTAssertEqualObjects([@"unified front" indefiniteArticle], @"a");
     XCTAssertEqualObjects([@"UN ambassedor" indefiniteArticle], @"a");
     XCTAssertEqualObjects([@"UK representitive" indefiniteArticle], @"a");
+}
+
+- (void)testSpecialCapitalizedCases
+{
+    XCTAssertEqualObjects([@"MN"  indefiniteArticle], @"an");
+    XCTAssertEqualObjects([@"FAA" indefiniteArticle], @"an");
+    XCTAssertEqualObjects([@"JOB" indefiniteArticle], @"a");
+    XCTAssertEqualObjects([@"URL" indefiniteArticle], @"a");
+    XCTAssertEqualObjects([@"USB" indefiniteArticle], @"a");
+    XCTAssertEqualObjects([@"XIP" indefiniteArticle], @"an");
+}
+
+- (void)testOddCases
+{
+    XCTAssertEqualObjects([@"\"quoted\"" indefiniteArticle], @"a");
+    XCTAssertEqualObjects([@" leading space" indefiniteArticle], @"a");
+    XCTAssertEqualObjects([@"®" indefiniteArticle], @"a");
 }
 
 @end


### PR DESCRIPTION
So now, empty string returns empty string, but anything else wacky (i.e. any non-word) will default to "a"
